### PR TITLE
Renovate should update the digest in `.plugin-versions`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,9 @@
       "customType": "regex",
       "fileMatch": ["^\\.plugin-versions$"],
       "matchStrings": [
-        "(?<depName>\\S+)\\W*(?<packageName>https:\\/\\/github.com\\/[\\S]+)\\W*(?<currentValue>[a-f0-9]{7,40})"
+        "(?<depName>\\S+)\\W*(?<packageName>https:\\/\\/github.com\\/[\\S]+)\\W*(?<currentDigest>[a-f0-9]{7,40})"
       ],
+      "autoReplaceStringTemplate": "{{{depName}}} {{{packageName}}} {{{newDigest}}}",
       "datasourceTemplate": "git-refs",
       "versioningTemplate": "git"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "customType": "regex",
       "fileMatch": ["^\\.plugin-versions$"],
       "matchStrings": [
-        "(?<depName>\\S+)\\W*(?<packageName>https:\\/\\/github.com\\/[\\S]+)\\W*(?<currentDigest>[a-f0-9]{7,40})"
+        "(?<depName>\\S+)\\W*(?<packageName>https:\\/\\/github.com\\/[\\S]+)\\W*(?<currentValue>[a-f0-9]{7,40})"
       ],
       "autoReplaceStringTemplate": "{{{depName}}} {{{packageName}}} {{{newDigest}}}",
       "datasourceTemplate": "git-refs",


### PR DESCRIPTION
Inspired by:
- https://docs.renovatebot.com/configuration-options/#autoreplacestringtemplate
- https://docs.renovatebot.com/modules/manager/regex/#updating-gitlab-ci-include-dep-names
- https://docs.renovatebot.com/modules/datasource/python-version/#example-custom-manager
