### PR TITLE
Renovate: Detect `.plugin-versions` current digest/value separately

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "customType": "regex",
       "fileMatch": ["^\\.plugin-versions$"],
       "matchStrings": [
-        "(?<depName>\\S+)\\W*(?<packageName>https:\\/\\/github.com\\/[\\S]+)\\W*(?<currentValue>[a-f0-9]{7,40})"
+        "(?<depName>\\S+)\\W*(?<packageName>https:\\/\\/github.com\\/[\\S]+)\\W*(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})"
       ],
       "autoReplaceStringTemplate": "{{{depName}}} {{{packageName}}} {{{newDigest}}}",
       "datasourceTemplate": "git-refs",


### PR DESCRIPTION
As found over in:
- https://github.com/renovatebot/renovate/discussions/8402
   >If I add `currentValue` as an empty group to the regex [...] it works.

To avoid results from job like these:
- https://developer.mend.io/github/MPV/dotfiles/-/job/d2edb710-d54e-4bde-b98d-327f1cb0c223

With no updates found:
```json
          {
            "depName": ".asdf/plugins/tflint",
            "packageName": "https://github.com/skyzyx/asdf-tflint.git",
            "currentValue": "master",
            "currentDigest": "37e7eb9b758bbe77319ee312fc3764ef9d0944aa",
            "updates": [],
            "versioning": "git",
            "warnings": []
          },
```

Regex tested at:
- https://regex101.com/r/YaruP5/2

---

This is a follow-up PR to:
- https://github.com/MPV/dotfiles/pull/85

And tries to solve:
- https://github.com/MPV/dotfiles/issues/84