### PR TITLE
Renovate `.plugin-versions` with `indentation` and `registryUrl`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,9 @@
       "customType": "regex",
       "fileMatch": ["^\\.plugin-versions$"],
       "matchStrings": [
-        "(?<depName>\\S+)\\W*(?<packageName>https:\\/\\/github.com\\/[\\S]+)\\W*(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})"
+        "(?<depName>\\S+)(?<indentation>\\W*)(?<registryUrl>https:\\\/\\\/github.com\\\/[\\S]+)\\W*(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})"
       ],
-      "autoReplaceStringTemplate": "{{{depName}}} {{{packageName}}} {{{newDigest}}}",
+      "autoReplaceStringTemplate": "{{{depName}}}{{indentation}}{{{registryUrl}}} {{{newDigest}}}",
       "datasourceTemplate": "git-refs",
       "versioningTemplate": "git"
     }


### PR DESCRIPTION
Regex tested at:
- https://regex101.com/r/YaruP5/3

Indentation described at:
- https://docs.renovatebot.com/modules/manager/regex/#optional-capture-groups

Registry url interpreted from (hoping for changelog):
- https://docs.renovatebot.com/modules/datasource/git-refs/