### PR TITLE
Renovate `.plugin-versions` without `newDigestShort` (until solved)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "matchStrings": [
         "(?<depName>\\S+)(?<indentation>\\s*)(?<packageName>https:\\\/\\\/github.com\\\/[\\S]+)\\W*(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})"
       ],
-      "autoReplaceStringTemplate": "{{{depName}}}{{indentation}}{{{packageName}}} {{{newDigestShort}}}",
+      "autoReplaceStringTemplate": "{{{depName}}}{{indentation}}{{{packageName}}} {{{newDigest}}}",
       "datasourceTemplate": "git-refs",
       "versioningTemplate": "git"
     }


### PR DESCRIPTION
As demonstrated here:
- https://github.com/renovatebot/renovate/discussions/33076
- https://github.com/renovatebot/renovate/discussions/33076#discussioncomment-12298305