### PR TITLE
Tune Renovate config to cut PR noise while keeping tools in tandem

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "git-submodules": {
     "enabled": true
   },
+  "prConcurrentLimit": 60,
   "customManagers": [
     {
       "customType": "regex",
@@ -17,15 +18,29 @@
     }
   ],
   "ignoreTests": true,
-  "prConcurrentLimit": 60,
   "packageRules": [
     {
       "description": [
-        "Automerge ASDF plugins (git submodules)"
+        "Combine the two representations of each asdf plugin (git submodule +",
+        ".plugin-versions digest) into a single branch so they upgrade together,",
+        "then automerge. Using automergeType 'pr' first to verify the grouping",
+        "and merge path; switch to 'branch' afterwards to drop the PR entirely."
       ],
       "matchManagers": ["git-submodules"],
       "matchDepNames": [".asdf/plugins/*"],
-      "automerge": true
+      "groupName": "asdf plugins",
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": [
+        "Same group as the submodule digests, so the .plugin-versions digest for",
+        "each plugin lands in the same branch/commit instead of a separate one."
+      ],
+      "matchFileNames": [".plugin-versions"],
+      "groupName": "asdf plugins",
+      "automerge": true,
+      "automergeType": "pr"
     },
     {
       "description": [

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "git-submodules": {
     "enabled": true
   },
+  "dependencyDashboard": true,
   "prConcurrentLimit": 60,
   "customManagers": [
     {


### PR DESCRIPTION
Focused first step toward cutting Renovate PR noise, based on the PR history (asdf plugin-script digests — java especially, ~4.8 PRs/week — were ~64% of merged commits).

Two commits:

## 1. Combine both representations of each asdf plugin
The `git-submodules` digests and the `.plugin-versions` custom-manager digests now share one `groupName: "asdf plugins"`, so a plugin's two representations upgrade together in a single branch instead of racing as separate updates. (1 or 2 commits on the branch — whichever suits Renovate — is fine.)

The group uses `automerge: true` with `automergeType: "pr"` so the first combined update opens as a visible PR — letting us confirm both representations land together and that the merge path works (there's no CI; `ignoreTests` is on). Once verified, this flips to `automergeType: "branch"` so plugin bumps stop surfacing as PRs at all.

## 2. Enable `dependencyDashboard`
Surfaces pending and held updates in a single dashboard issue.

## Note
Renovate reads its config from the default branch, so this only takes effect once merged to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)