### PR TITLE
Remove orphaned grafana asdf plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "golang"]
 	path = .asdf/plugins/golang
 	url = https://github.com/kennyp/asdf-golang.git
-[submodule "grafana"]
-	path = .asdf/plugins/grafana
-	url = https://github.com/baysao/asdf-grafana.git
 [submodule "helm-ct"]
 	path = .asdf/plugins/helm-ct
 	url = https://github.com/tablexi/asdf-helm-ct.git

--- a/.plugin-versions
+++ b/.plugin-versions
@@ -8,7 +8,6 @@ clusterctl           https://github.com/pfnet-research/asdf-clusterctl.git 4042c
 etcd                 https://github.com/particledecay/asdf-etcd.git 8a29f94778e0b204f5ad9a1cdf4c810999410d22
 github-cli           https://github.com/bartlomiejdanek/asdf-github-cli.git     e0605b7
 golang               https://github.com/kennyp/asdf-golang.git a75b761963d8e6eda1a185c73476da8a75b8d300
-grafana              https://github.com/baysao/asdf-grafana.git                 429a9af
 helm-ct              https://github.com/tablexi/asdf-helm-ct.git                3e3ec87
 helm                 https://github.com/Antiarchitect/asdf-helm.git 3a6dcbba19ca2a7c4bd7c43eb0e2a35736e6bce7
 java                 https://github.com/halcyon/asdf-java.git 52476f47753114d46b61745022972303871cb181


### PR DESCRIPTION
Fixes the `❌ ERROR: lookupUpdates error` shown on the Renovate dependency dashboard (issue #6).

## Cause
The Renovate job log pinpointed a single failing dependency — `grafana` — which errors in **both** managers that track it:

```
git-submodules:  .asdf/plugins/grafana → https://github.com/baysao/asdf-grafana.git   "skipReason": "internal-error"
regex:           grafana               → https://github.com/baysao/asdf-grafana.git   "skipReason": "internal-error"
```

`baysao/asdf-grafana` is unreachable upstream (deleted/renamed/private), so its `git-refs` digest lookup throws. Every other one of the 122 detected deps resolves fine.

## Fix
`grafana` is an **orphan** — it isn't referenced in `.tool-versions`, so no tool actually installs it. This removes the dead weight:

- the git submodule (`.gitmodules` entry + `.asdf/plugins/grafana` gitlink)
- the `grafana` line in `.plugin-versions`

Net: 3 files changed, 5 deletions. Nothing in use is affected. After this merges, the dashboard error clears on Renovate's next run (or immediately via the "run again" checkbox on issue #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JC3EfqgoRTkSM2Aij8tTj)_