### PR TITLE
Renovate: branch-merge the asdf plugins group (no PRs)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,14 +26,13 @@
       "description": [
         "Combine the two representations of each asdf plugin (git submodule +",
         ".plugin-versions digest) into a single branch so they upgrade together,",
-        "then automerge. Using automergeType 'pr' first to verify the grouping",
-        "and merge path; switch to 'branch' afterwards to drop the PR entirely."
+        "then merge straight to the branch without opening a PR."
       ],
       "matchManagers": ["git-submodules"],
       "matchDepNames": [".asdf/plugins/*"],
       "groupName": "asdf plugins",
       "automerge": true,
-      "automergeType": "pr"
+      "automergeType": "branch"
     },
     {
       "description": [
@@ -43,7 +42,7 @@
       "matchFileNames": [".plugin-versions"],
       "groupName": "asdf plugins",
       "automerge": true,
-      "automergeType": "pr"
+      "automergeType": "branch"
     },
     {
       "description": [


### PR DESCRIPTION
Now that the combined `asdf plugins` grouping has been verified working (the recent java update grouped and merged cleanly), switch it from PR-based automerge to **branch** automerge.

## Change
Both plugin rules (the `git-submodules` digests and the `.plugin-versions` custom-manager digests) flip `automergeType: "pr"` → `"branch"`.

Effect: asdf plugin-digest updates now merge straight to the branch and **no longer open PRs at all** — eliminating the dominant source of Renovate PR noise (previously ~4.8 java-digest PRs/week, ~64% of merged commits) while keeping the plugins current and their two representations upgrading together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JC3EfqgoRTkSM2Aij8tTj)_