### PR TITLE
Cache zsh completion dump for faster shell startup

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,12 @@
-# Make tab-completion work without errors (command not found: compdef)
-autoload -Uz compinit && compinit
+# Make tab-completion work without errors (command not found: compdef).
+# Only rebuild the completion dump (and run its security check) once a day;
+# every other startup reuses the cache via `compinit -C` for faster shells.
+autoload -Uz compinit
+if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
+	compinit
+else
+	compinit -C
+fi
 
 [ -f /usr/local/opt/antidote/share/antidote/antidote.zsh ] && source /usr/local/opt/antidote/share/antidote/antidote.zsh
 [ -f /opt/homebrew/opt/antidote/share/antidote/antidote.zsh ] && source /opt/homebrew/opt/antidote/share/antidote/antidote.zsh


### PR DESCRIPTION
## What

Gate `compinit` so the completion dump is regenerated (and its insecure-directory security check run) at most once per day. Every other shell startup reuses the cached dump via `compinit -C`.

```zsh
autoload -Uz compinit
if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
	compinit
else
	compinit -C
fi
```

## Why

`compinit` currently runs in full on every shell launch, rescanning `fpath` and re-running the security check each time. The `mh+24` glob qualifier matches the dump only when it's older than 24h, so the expensive path runs at most daily while normal launches skip straight to the cached dump.

## Notes

- Touches the same top region of `.zshrc` as #908 (static antidote bundle); whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En38opDwLCjZSh9z9JKEyW