### PR TITLE
Load zsh plugins from a static antidote bundle

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,9 +1,20 @@
 # Make tab-completion work without errors (command not found: compdef)
 autoload -Uz compinit && compinit
 
-[ -f /usr/local/opt/antidote/share/antidote/antidote.zsh ] && source /usr/local/opt/antidote/share/antidote/antidote.zsh
-[ -f /opt/homebrew/opt/antidote/share/antidote/antidote.zsh ] && source /opt/homebrew/opt/antidote/share/antidote/antidote.zsh
-antidote load
+# Antidote: source a statically-generated plugin bundle for fast startup,
+# regenerating it only when the plugin list (~/.zsh_plugins.txt) changes.
+# See: https://getantidote.github.io/usage#static
+zsh_plugins=${ZDOTDIR:-$HOME}/.zsh_plugins
+if [[ ! ${zsh_plugins}.zsh -nt ${zsh_plugins}.txt ]]; then
+	for antidote_dir in /opt/homebrew/opt/antidote /usr/local/opt/antidote; do
+		if [ -f "${antidote_dir}/share/antidote/antidote.zsh" ]; then
+			source "${antidote_dir}/share/antidote/antidote.zsh"
+			antidote bundle <"${zsh_plugins}.txt" >"${zsh_plugins}.zsh"
+			break
+		fi
+	done
+fi
+[ -f "${zsh_plugins}.zsh" ] && source "${zsh_plugins}.zsh"
 
 # Starship
 eval "$(starship init zsh)"


### PR DESCRIPTION
## What

Replace the dynamic `antidote load` with antidote's documented [static](https://getantidote.github.io/usage#static) pattern: source a pre-generated `~/.zsh_plugins.zsh` directly, regenerating it only when `~/.zsh_plugins.txt` changes.

```zsh
zsh_plugins=${ZDOTDIR:-$HOME}/.zsh_plugins
if [[ ! ${zsh_plugins}.zsh -nt ${zsh_plugins}.txt ]]; then
	for antidote_dir in /opt/homebrew/opt/antidote /usr/local/opt/antidote; do
		if [ -f "${antidote_dir}/share/antidote/antidote.zsh" ]; then
			source "${antidote_dir}/share/antidote/antidote.zsh"
			antidote bundle <"${zsh_plugins}.txt" >"${zsh_plugins}.zsh"
			break
		fi
	done
fi
[ -f "${zsh_plugins}.zsh" ] && source "${zsh_plugins}.zsh"
```

## Why

`antidote load` sources antidote and reprocesses the plugin list on every startup. Sourcing the generated bundle directly avoids loading antidote entirely on normal launches — the generator only runs when the plugin list is newer than the bundle. The loop covers both Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local`) Homebrew prefixes, matching the existing dual-path handling.

## Notes

- First launch after this change regenerates the bundle once, then caches.
- Touches the same top region of `.zshrc` as the compinit-cache PR; whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En38opDwLCjZSh9z9JKEyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01En38opDwLCjZSh9z9JKEyW)_