### PR TITLE
Enable 24-bit true color in tmux

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -41,7 +41,10 @@ set -g history-limit 50000
 ##########
 
 # Initial setup
-set -g default-terminal xterm-256color
+# Use a tmux-aware terminfo inside tmux and advertise 24-bit ("true") colour
+# to the outer terminal (iTerm2 / kitty) so Dracula themes render full RGB.
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB,xterm-kitty:RGB"
 set -g status-keys vi
 
 # remap prefix from 'C-b' to 'C-a'


### PR DESCRIPTION
## What

Switch `default-terminal` to `tmux-256color` and advertise the `RGB` terminfo capability for the outer terminals:

```tmux
set -g default-terminal "tmux-256color"
set -ag terminal-overrides ",xterm-256color:RGB,xterm-kitty:RGB"
```

## Why

With `default-terminal xterm-256color` and no `RGB`/`Tc` override, tmux quantizes 24-bit colors to the 256-color palette. The override advertises true-color support for iTerm2 (`xterm-256color`) and kitty (`xterm-kitty`), so Dracula themes render with full RGB inside tmux.

## Verify

`tmux-256color` needs to exist in the local terminfo database. Modern macOS ships it; if a machine is missing it, `tic` a copy or fall back to `screen-256color`. Quick check inside a fresh tmux:

```sh
tmux info | grep -i rgb   # expect: RGB: (flag) true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En38opDwLCjZSh9z9JKEyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01En38opDwLCjZSh9z9JKEyW)_