### PR TITLE
Remove dead set-titles-string override in tmux

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,7 +1,6 @@
 set-option -g set-titles on
 #set-option -g set-titles-string '#T'
 #set-option -g set-titles-string "#{pane_title} #{session_alerts} \t (#S)"
-set-option -g set-titles-string "#I-#P \t #{pane_title} #{session_alerts}"
 set-option -g set-titles-string "#I-#P \t #{pane_current_path} \t #{pane_current_command} #{pane_title} #{session_alerts}"
 #set-option -g set-titles-string "#S / #W"
 # https://man7.org/linux/man-pages/man1/tmux.1.html#FORMATS


### PR DESCRIPTION
## What

Delete the first of two consecutive `set-option -g set-titles-string` lines.

## Why

The two lines ran back-to-back, so the first (`"#I-#P \t #{pane_title} #{session_alerts}"`) was immediately overwritten by the second and never took effect. Only the second — which includes `pane_current_path` and `pane_current_command` — was ever applied. Removing the dead line leaves behavior unchanged and the config unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01En38opDwLCjZSh9z9JKEyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01En38opDwLCjZSh9z9JKEyW)_